### PR TITLE
Recode startup join timeout

### DIFF
--- a/src/main/java/com/kamesuta/bungeepteropower/Config.java
+++ b/src/main/java/com/kamesuta/bungeepteropower/Config.java
@@ -55,6 +55,12 @@ public class Config {
      */
     public final int startupJoinTimeout;
     /**
+     * Once the server is pingable, wait the specified amount of seconds before sending the player to the server
+     * This is useful to wait for plugins like Luckperms to fully load
+     * If you set it to 0, the player will be connected as soon as the server is pingable
+     */
+    public final int joinDelay;
+    /**
      * The number of seconds between pings to check the server status
      */
     public final int pingInterval;
@@ -98,6 +104,7 @@ public class Config {
             // Startup join settings
             this.startupJoinTimeout = configuration.getInt("startupJoin.timeout");
             this.pingInterval = configuration.getInt("startupJoin.pingInterval");
+            this.joinDelay = configuration.getInt("startupJoin.joinDelay");
 
             // Pterodactyl API credentials
             this.pterodactylUrl = new URI(configuration.getString("pterodactyl.url"));

--- a/src/main/java/com/kamesuta/bungeepteropower/ServerController.java
+++ b/src/main/java/com/kamesuta/bungeepteropower/ServerController.java
@@ -3,12 +3,10 @@ package com.kamesuta.bungeepteropower;
 import com.kamesuta.bungeepteropower.api.PowerSignal;
 import net.md_5.bungee.api.Callback;
 import net.md_5.bungee.api.CommandSender;
-import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.ServerPing;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 
-import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -77,35 +75,21 @@ public class ServerController {
      * @return A future that completes when the server is started
      */
     private static CompletableFuture<Void> onceStarted(ServerInfo serverInfo) {
-        CompletableFuture<Void> future = new CompletableFuture<Void>();
-
-        // The timestamp when the server is expected to be started within
-        Instant timeout = Instant.now().plusSeconds(plugin.config.startupJoinTimeout);
-
-        // Ping the server and check if it is started
-        Callback<ServerPing> callback = new Callback<>() {
+        CompletableFuture<Void> future = new CompletableFuture<Void>().orTimeout(plugin.config.startupJoinTimeout, TimeUnit.SECONDS);
+        Callback<ServerPing> callback = new Callback<ServerPing>() {
             @Override
             public void done(ServerPing serverPing, Throwable throwable) {
-                // If the server is started, complete the future
+                if (future.isDone())
+                    return;
                 if (throwable == null && serverPing != null) {
                     future.complete(null);
                     return;
                 }
-                // Not started yet, retry after a while
-                if (Instant.now().isBefore(timeout)) {
-                    ProxyServer.getInstance().getScheduler()
-                            .schedule(plugin, () -> serverInfo.ping(this), plugin.config.pingInterval, TimeUnit.SECONDS);
-                    return;
-                }
-
-                // If the server is not started within the timeout, complete the future exceptionally
-                future.completeExceptionally(new RuntimeException("Server did not start in autoJoinTimeout"));
+                plugin.getProxy().getScheduler().schedule(plugin, ()-> serverInfo.ping(this), plugin.config.pingInterval, TimeUnit.SECONDS);
             }
         };
         serverInfo.ping(callback);
-
         return future;
-
     }
 
 }

--- a/src/main/java/com/kamesuta/bungeepteropower/ServerController.java
+++ b/src/main/java/com/kamesuta/bungeepteropower/ServerController.java
@@ -38,7 +38,7 @@ public class ServerController {
                 onceStarted(serverInfo).thenRun(() -> {
                     // Move player to the started server
                     ProxiedPlayer player = (ProxiedPlayer) sender;
-                    player.connect(serverInfo);
+                    plugin.getProxy().getScheduler().schedule(plugin, ()->player.connect(serverInfo), 5, TimeUnit.SECONDS);
                 }).exceptionally((Throwable e) -> {
                     sender.sendMessage(plugin.messages.warning("server_startup_join_warning", serverName));
                     return null;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -28,6 +28,11 @@ startupJoin:
   # If you set it to 0, the plugin will not try to connect the player to the server
   timeout: 60
 
+  # Once the server is pingable, wait the specified amount of seconds before sending the player to the server
+  # This is useful to wait for plugins like Luckperms to fully load
+  # If you set it to 0, the player will be connected as soon as the server is pingable
+  joinDelay: 5
+
   # The number of seconds between pings to check the server status
   pingInterval: 3
 


### PR DESCRIPTION
- Use CompletableFuture orTimeout to manage timeout (changes almost nothing, but better code)
- Add extra 5 seconds before moving the player to the server:
      When joining the server immediately after it's online, some plugins like luckperms will kick you because the plugin is not fully loaded yet.
      Can't really find a solution except adding another delay